### PR TITLE
Fix trim arguments for Mongo Documents

### DIFF
--- a/lib/client/kadira.js
+++ b/lib/client/kadira.js
@@ -46,7 +46,7 @@ Kadira.sendErrors = function (errors) {
             return true;
           }).map(function (item) {
             if(item.document) {
-              item.document = prepareArguments(item.document);
+              item.document = prepareArgument(item.document);
             }
             return item;
           });
@@ -80,14 +80,21 @@ Kadira.sendErrors = function (errors) {
 
   function prepareArguments(args) {
     if(args) {
-      return args.map(function (argument) {
-        // replace if stringified argument is bigger than 1kb
-        if(argument && JSON.stringify(argument).length > 1024) {
-          return '--- argument size exceeds limit ---';
-        } else {
-          return argument;
-        }
-      });
+      return args.map(prepareArgument);
+    }
+  }
+
+  function prepareArgument (argument) {
+    // process arguments before sending
+    return trimIfLarger(argument);
+  }
+
+  function trimIfLarger (argument) {
+    // replace if stringified argument is bigger than 1kb
+    if(argument && JSON.stringify(argument).length > 1024) {
+      return '--- argument size exceeds limit ---';
+    } else {
+      return argument;
     }
   }
 }


### PR DESCRIPTION
`prepareArguments()` only processes arrays of arguments.
Create a new `prepareArgument()` to process a single argument
Use the new `prepareArgument()` to proces the document
