### PR TITLE
Fix bug: sendSavedErrors was not defined

### DIFF
--- a/lib/client/kadira.js
+++ b/lib/client/kadira.js
@@ -4,12 +4,6 @@ Kadira.options = __meteor_runtime_config__.kadira;
 Kadira.options.errorDumpInterval = Kadira.options.errorDumpInterval || 1000*60;
 Kadira.options.maxErrorsPerInterval = Kadira.options.maxErrorsPerInterval || 10;
 
-if(Kadira.options && Kadira.options.endpoint) {
-  Kadira.syncedDate = new Ntp(Kadira.options.endpoint);
-  Kadira.syncedDate.sync();
-  setInterval(Kadira.sendSavedErrors, Kadira.options.errorDumpInterval);
-}
-
 Kadira.errors = {};
 Kadira.sendSavedErrors = function () {
   var errors = _.values(Kadira.errors);
@@ -22,6 +16,12 @@ Kadira.sendSavedErrors = function () {
   if(errors && errors.length) {
     Kadira.sendErrors(errors);
   }
+}
+
+if(Kadira.options && Kadira.options.endpoint) {
+  Kadira.syncedDate = new Ntp(Kadira.options.endpoint);
+  Kadira.syncedDate.sync();
+  setInterval(Kadira.sendSavedErrors, Kadira.options.errorDumpInterval);
 }
 
 Kadira.trackError = function (error) {


### PR DESCRIPTION
Causes error "[client] Cannot read property 'apply' of undefined"
Does not send duplicate errors with same message
