### PR TITLE
Add option to disable collecting all stacks

### DIFF
--- a/lib/client/error_reporters/zone.js
+++ b/lib/client/error_reporters/zone.js
@@ -1,6 +1,7 @@
 if(Kadira.options && Kadira.options.appId) {
   Zone.Reporters.add('kadira', kadiraZoneReporter);
   Zone.prototype.getTime = getTime;
+  Zone.collectAllStacks = Kadira.options.collectAllStacks;
 }
 
 function kadiraZoneReporter(zone) {

--- a/lib/client/kadira.js
+++ b/lib/client/kadira.js
@@ -4,6 +4,10 @@ Kadira.options = __meteor_runtime_config__.kadira || {};
 Kadira.options.errorDumpInterval = Kadira.options.errorDumpInterval || 1000*60;
 Kadira.options.maxErrorsPerInterval = Kadira.options.maxErrorsPerInterval || 10;
 
+if(Kadira.options.collectAllStacks === undefined) {
+  Kadira.options.collectAllStacks = false;
+}
+
 Kadira.errors = {};
 Kadira.sendSavedErrors = function () {
   var errors = _.values(Kadira.errors);


### PR DESCRIPTION
Errored zone stack is still collected
Defaults to not collecting all traces
Can be enabled by setting 'collectAllStacks' option to true
This is done to increase performance
