### PR TITLE
Fix zone if undefined bug

### DIFF
--- a/lib/client/error_reporters/meteor_debug.js
+++ b/lib/client/error_reporters/meteor_debug.js
@@ -1,7 +1,7 @@
 var originalMeteorDebug = Meteor._debug;
 
 Meteor._debug = function(message, stack) {
-  if(!zone) {
+  if(!window.zone) {
     var err = new Error(message);
     err.stack = stack;
     var stack = getNormalizedStacktrace(err);

--- a/lib/client/error_reporters/zone.js
+++ b/lib/client/error_reporters/zone.js
@@ -1,4 +1,4 @@
-if(Kadira.options && Kadira.options.appId) {
+if(window.Zone && Zone.inited && Kadira.options.appId) {
   Zone.Reporters.add('kadira', kadiraZoneReporter);
   Zone.prototype.getTime = getTime;
   Zone.collectAllStacks = Kadira.options.collectAllStacks;


### PR DESCRIPTION
- check `window.zone` instead of `zone`
- improve checking whether zone is avaiable before adding reporters
