### PR TITLE
Fix XDR protocol bug

### DIFF
--- a/lib/client/kadira.js
+++ b/lib/client/kadira.js
@@ -54,6 +54,7 @@ if(Kadira.options && Kadira.options.endpoint) {
 /**
  * IE8 and IE9 does not support CORS with the usual XMLHttpRequest object
  * If XDomainRequest exists, use it to send errors.
+ * XDR can POST data to HTTPS endpoints only if current page uses HTTPS
  */
 if (window.XDomainRequest) {
   $.ajaxTransport(function(s) {
@@ -61,6 +62,7 @@ if (window.XDomainRequest) {
       send: function (headers, callback) {
         var xdr = new XDomainRequest();
         var data = s.data || null;
+        var url = matchPageProtocol(s.url);
 
         xdr.onload = function () {
           var headers = {'Content-Type': xdr.contentType};
@@ -71,9 +73,14 @@ if (window.XDomainRequest) {
           callback(404);
         }
 
-        xdr.open(s.type, s.url);
+        xdr.open(s.type, url);
         xdr.send(data);
       }
     };
   });
+}
+
+function matchPageProtocol (endpoint) {
+  var withoutProtocol = endpoint.substr(endpoint.indexOf(':'));
+  return window.location.protocol + withoutProtocol;
 }


### PR DESCRIPTION
Replace endpoint protocol with protocol used by the page
XDR cannot post to https from a page running on http
