### PR TITLE
Updated to Meteor.wrapAsync

### DIFF
--- a/lib/models/system.js
+++ b/lib/models/system.js
@@ -7,7 +7,8 @@ SystemModel = function () {
   try {
     var usage = (typeof KadiraBinaryDeps != 'undefined')?
       KadiraBinaryDeps.usage: Npm.require('usage');
-    this.usageLookup = Meteor.wrapAsync(usage.lookup.bind(usage));
+    var wrapAsync = Meteor.wrapAsync || Meteor._wrapAsync;
+    this.usageLookup = wrapAsync(usage.lookup.bind(usage));
   } catch(ex) {
     console.error('Kadira: usage npm module loading failed - ', ex.message);
   }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -14,3 +14,7 @@ UniqueId.prototype.get = function() {
 };
 
 DefaultUniqueId = new UniqueId();
+
+// User new, documented Meteor.wrapAsync while supporting older versions
+// of Meteor that only have Meteor._wrapAsync
+wrapAsync = Meteor.wrapAsync || Meteor._wrapAsync;

--- a/tests/_helpers/init.js
+++ b/tests/_helpers/init.js
@@ -16,7 +16,7 @@ Meteor.publish('tinytest-data-2', function() {
 });
 
 Meteor.publish('tinytest-data-delayed', function() {
-  Meteor.wrapAsync(function(done) {
+  wrapAsync(function(done) {
     setTimeout(done, 200);
   })();
   return TestData.find();

--- a/tests/hijack/async.js
+++ b/tests/hijack/async.js
@@ -28,7 +28,7 @@ Tinytest.add(
   function (test) {
     EnableTrackingMethods();
     var methodId = RegisterMethod(function () {
-      var wait = Meteor.wrapAsync(function(waitTime, callback) {
+      var wait = wrapAsync(function(waitTime, callback) {
         setTimeout(function () {
           callback(new Error('error'));
         }, waitTime);

--- a/tests/models/system.js
+++ b/tests/models/system.js
@@ -4,7 +4,7 @@ Tinytest.add(
   function (test) {
     var beforeTime = (new Date).getTime();
     var model = new SystemModel();
-    Meteor.wrapAsync(function(callback) {
+    wrapAsync(function(callback) {
       setTimeout(callback, 1000);
     })();
     var payload = model.buildPayload().systemMetrics[0];


### PR DESCRIPTION
switched from previously undocumented and now deprecated Meteor._wrapAsync to the new official Meteor.wrapAsync.

Removes the following warning that users currently get on server startup:

Meteor._wrapAsync has been renamed to Meteor.wrapAsync undefined
