### PR TITLE
Defer error tracking

### DIFF
--- a/lib/hijack/error.js
+++ b/lib/hijack/error.js
@@ -1,59 +1,69 @@
-process.on('uncaughtException', function (err) {
-  // let the server crash normally if error tracking is disabled
-  if(!Kadira.options.enableErrorTracking) {
-    throw err;
-  }
 
-  // looking for already tracked errors and throw them immediately
-  // throw error immediately if kadira is not ready
-  if(err._tracked || !Kadira.connected) {
-    throw err;
-  }
-
-  var trace = getTrace(err, 'server-crash', 'uncaughtException');
-  Kadira.models.error.trackError(err, trace);
-  Kadira.sendPayload(function () {
-    clearTimeout(timer);
-    throwError(err);
-  });
-
-  var timer = setTimeout(function () {
-    throwError(err);
-  }, 1000*10);
-
-  function throwError(err) {
-    // sometimes error came back from a fiber.
-    // But we don't fibers to track that error for us
-    // That's why we throw the error on the nextTick
-    process.nextTick(function() {
-      // we need to mark this error where we really need to throw
-      err._tracked = true;
-      throw err;
-    });
-  }
-});
-
-var originalMeteorDebug = Meteor._debug;
-Meteor._debug = function (message, stack) {
-  if(!Kadira.options.enableErrorTracking) {
-    return originalMeteorDebug.call(this, message, stack);
-  }
-
-  // We've changed `stack` into an object at method and sub handlers so we can
-  // ignore them here. These errors are already tracked so don't track again.
-  if(stack && stack.stack) {
-    stack = stack.stack
-  } else {
-    // only send to the server, if only connected to kadira
-    if(Kadira.connected) {
-      var error = new Error(message);
-      error.stack = stack;
-      var trace = getTrace(error, 'server-internal', 'Meteor._debug');
-      Kadira.models.error.trackError(error, trace);
+TrackUncaughtExceptions = function () {
+  process.on('uncaughtException', function (err) {
+    // skip errors with `_skipKadira` flag
+    if(err._skipKadira) {
+      return;
     }
-  }
 
-  return originalMeteorDebug.apply(this, arguments);
+    // let the server crash normally if error tracking is disabled
+    if(!Kadira.options.enableErrorTracking) {
+      throw err;
+    }
+
+    // looking for already tracked errors and throw them immediately
+    // throw error immediately if kadira is not ready
+    if(err._tracked || !Kadira.connected) {
+      throw err;
+    }
+
+    var trace = getTrace(err, 'server-crash', 'uncaughtException');
+    Kadira.models.error.trackError(err, trace);
+    Kadira.sendPayload(function () {
+      clearTimeout(timer);
+      throwError(err);
+    });
+
+    var timer = setTimeout(function () {
+      throwError(err);
+    }, 1000*10);
+
+    function throwError(err) {
+      // sometimes error came back from a fiber.
+      // But we don't fibers to track that error for us
+      // That's why we throw the error on the nextTick
+      process.nextTick(function() {
+        // we need to mark this error where we really need to throw
+        err._tracked = true;
+        throw err;
+      });
+    }
+  });
+}
+
+TrackMeteorDebug = function () {
+  var originalMeteorDebug = Meteor._debug;
+  Meteor._debug = function (message, stack) {
+    if(!Kadira.options.enableErrorTracking) {
+      return originalMeteorDebug.call(this, message, stack);
+    }
+
+    // We've changed `stack` into an object at method and sub handlers so we can
+    // ignore them here. These errors are already tracked so don't track again.
+    if(stack && stack.stack) {
+      stack = stack.stack
+    } else {
+      // only send to the server, if only connected to kadira
+      if(Kadira.connected) {
+        var error = new Error(message);
+        error.stack = stack;
+        var trace = getTrace(error, 'server-internal', 'Meteor._debug');
+        Kadira.models.error.trackError(error, trace);
+      }
+    }
+
+    return originalMeteorDebug.apply(this, arguments);
+  }
 }
 
 function getTrace(err, type, subType) {

--- a/lib/kadira.js
+++ b/lib/kadira.js
@@ -67,6 +67,14 @@ Kadira.connect = function(appId, appSecret, options) {
     throw new Error('Kadira: required appId and appSecret');
   }
 
+  // start tracking errors
+  Meteor.startup(function () {
+    Meteor.defer(function () {
+      TrackUncaughtExceptions();
+      TrackMeteorDebug();
+    })
+  })
+
   //start wrapping Meteor's internal methods
   Kadira._startInstrumenting(function() {
     console.log('Kadira: completed instrumenting the app')
@@ -256,4 +264,8 @@ Kadira.trackError = function (type, message, options) {
     };
     Kadira.models.error.trackError(error, trace);
   }
+}
+
+Kadira.ignoreError = function (err) {
+  err._skipKadira = true;
 }

--- a/lib/kadira.js
+++ b/lib/kadira.js
@@ -266,6 +266,6 @@ Kadira.trackError = function (type, message, options) {
   }
 }
 
-Kadira.ignoreError = function (err) {
+Kadira.ignoreErrorTracking = function (err) {
   err._skipKadira = true;
 }

--- a/lib/kadira.js
+++ b/lib/kadira.js
@@ -69,10 +69,8 @@ Kadira.connect = function(appId, appSecret, options) {
 
   // start tracking errors
   Meteor.startup(function () {
-    Meteor.defer(function () {
-      TrackUncaughtExceptions();
-      TrackMeteorDebug();
-    })
+    TrackUncaughtExceptions();
+    TrackMeteorDebug();
   })
 
   //start wrapping Meteor's internal methods


### PR DESCRIPTION
- allow user to track uncaughtExceptions
- user must ignore the error with `Kadira.ignoreError(err);`
