### PR TITLE
Fix Meteor.Error cloning

### DIFF
--- a/lib/hijack/wrap_session.js
+++ b/lib/hijack/wrap_session.js
@@ -194,7 +194,7 @@ function wrapMethodHanderForErrors(name, originalHandler, methodMap) {
 
 function cloneError(err) {
   if(err instanceof Meteor.Error) {
-    var newError = new Meteor.Error(err.error, err.reason);
+    var newError = err.clone();
   } else {
     var newError = new Error(err.message);
   }


### PR DESCRIPTION
Old code didn't preserve err.details. New code would preserve err.details and anything else that MDG might fancy putting in a Meteor.Error.