### PR TITLE
Double-connect does not crash app.

### DIFF
--- a/lib/kadira.js
+++ b/lib/kadira.js
@@ -20,6 +20,7 @@ Kadira.models.system = new SystemModel();
 
 
 Kadira.connect = function(appId, appSecret, options) {
+  if(Kadira.connected) { return; }
   options = options || {};
   options.appId = appId;
   options.appSecret = appSecret;


### PR DESCRIPTION
Issue #155.

I came across this same exact problem when starting up my app for the first time with Kadira. I wrapped `Kadira.connect` in the conditional `if(!Kadira.connected)` in our own code base, which seems to have fixed this problem completely. The problem seems to stem from `Kadira.connect` being called multiple times.

I wanted to submit this PR to hopefully fix this bug for everyone. I hope this helps. Thanks.