### PR TITLE
Fixed errors with tracking docSize and sentMsgSize

### DIFF
--- a/lib/models/pubsub.js
+++ b/lib/models/pubsub.js
@@ -341,13 +341,13 @@ PubsubModel.prototype.trackDocSize = function(name, type, size) {
   var metrics = this._getMetrics(timestamp, publication);
 
   if(type === "polledFetches") {
-    publication.polledDocSize += size;
+    metrics.polledDocSize += size;
   } else if(type === "liveFetches") {
-    publication.liveFetchedDocSize += size;
+    metrics.liveFetchedDocSize += size;
   } else if(type === "cursorFetches") {
-    publication.fetchedDocSize += size;
+    metrics.fetchedDocSize += size;
   } else if(type === "initialFetches") {
-    publication.initiallyFetchedDocSize += size;
+    metrics.initiallyFetchedDocSize += size;
   } else {
     throw new Error("Kadira: Unknown docs fetched type");
   }
@@ -359,9 +359,9 @@ PubsubModel.prototype.trackMsgSize = function(name, type, size) {
   var metrics = this._getMetrics(timestamp, publication);
 
   if(type === "liveSent") {
-    publication.liveSentMsgSize += size;
+    metrics.liveSentMsgSize += size;
   } else if(type === "initialSent") {
-    publication.initiallySentMsgSize += size;
+    metrics.initiallySentMsgSize += size;
   } else {
     throw new Error("Kadira: Unknown docs fetched type");
   }

--- a/tests/_helpers/helpers.js
+++ b/tests/_helpers/helpers.js
@@ -136,3 +136,13 @@ CloseClient = function(client) {
   checkClientExtence(sessionId);
   return f.wait();
 };
+
+WithDocCacheGetSize = function(fn, patchedSize){
+  var original = Kadira.docSzCache.getSize
+  Kadira.docSzCache.getSize = function(){return patchedSize}
+  try {
+    fn();
+  } finally {
+    Kadira.docSzCache.getSize = original
+  }
+}

--- a/tests/models/pubsub.js
+++ b/tests/models/pubsub.js
@@ -545,3 +545,83 @@ Tinytest.add(
     CloseClient(client);
   }
 );
+
+Tinytest.add(
+  'Models - PubSub - Observers - initiallySentMsgSize',
+  function (test) {
+    CleanTestData();
+    var client = GetMeteorClient();
+    TestData.insert({aa: 10});
+    TestData.insert({aa: 20});
+    Wait(50);
+    var h1 = SubscribeAndWait(client, 'tinytest-data-random');
+    Wait(100);
+    var payload = GetPubSubPayload();
+
+    var templateMsg = '{"msg":"added","collection":"tinytest-data","id":"17digitslongidxxx","fields":{"aa":10}}';
+    var expectedMsgSize = templateMsg.length * 2;
+
+    test.equal(payload[0].pubs['tinytest-data-random'].initiallySentMsgSize, expectedMsgSize);
+    CloseClient(client);
+  }
+);
+
+Tinytest.add(
+  'Models - PubSub - Observers - liveSentMsgSize',
+  function (test) {
+    CleanTestData();
+    var client = GetMeteorClient();
+    var h1 = SubscribeAndWait(client, 'tinytest-data-random');
+    Wait(50);
+    TestData.insert({aa: 10});
+    TestData.insert({aa: 20});
+    Wait(100);
+    var payload = GetPubSubPayload();
+
+    var templateMsg = '{"msg":"added","collection":"tinytest-data","id":"17digitslongidxxx","fields":{"aa":10}}';
+    var expectedMsgSize = templateMsg.length * 2;
+
+    test.equal(payload[0].pubs['tinytest-data-random'].liveSentMsgSize, expectedMsgSize);
+    CloseClient(client);
+  }
+);
+
+Tinytest.add(
+  'Models - PubSub - Observers - liveFetchedDocSize',
+  function (test) {
+    WithDocCacheGetSize(function () {
+      CleanTestData();
+
+      var client = GetMeteorClient();
+      var h1 = SubscribeAndWait(client, 'tinytest-data-random');
+      Wait(50);
+      TestData.insert({aa: 10});
+      TestData.insert({aa: 20});
+      Wait(100);
+      var payload = GetPubSubPayload();
+
+      test.equal(payload[0].pubs['tinytest-data-random'].liveFetchedDocSize, 50);
+      CloseClient(client);
+    }, 25);
+  }
+);
+
+Tinytest.add(
+  'Models - PubSub - Observers - initiallyFetchedDocSize',
+  function (test) {
+    WithDocCacheGetSize(function () {
+      CleanTestData();
+
+      var client = GetMeteorClient();
+      TestData.insert({aa: 10});
+      TestData.insert({aa: 20});
+      Wait(50);
+      var h1 = SubscribeAndWait(client, 'tinytest-data-random');
+      Wait(100);
+      var payload = GetPubSubPayload();
+
+      test.equal(payload[0].pubs['tinytest-data-random'].initiallyFetchedDocSize, 60);
+      CloseClient(client);
+    }, 30);
+  }
+);


### PR DESCRIPTION
Add tests for tracking initiallySentMsgSize, liveSentMsgSize, initiallyFetchedDocSize and liveFetchedDocSize.