### PR TITLE
DocSzCache size is now configurable

### DIFF
--- a/lib/environment_variables.js
+++ b/lib/environment_variables.js
@@ -83,4 +83,9 @@ Kadira._parseEnv._options = {
     name: 'proxy',
     parser: Kadira._parseEnv.parseUrl,
   },
+  // number of items cached for tracking document size
+  KADIRA_OPTIONS_DOCUMENT_SIZE_CACHE_SIZE: {
+    name: 'documentSizeCacheSize',
+    parser: Kadira._parseEnv.parseInt,
+  },
 };

--- a/lib/kadira.js
+++ b/lib/kadira.js
@@ -32,6 +32,10 @@ Kadira.connect = function(appId, appSecret, options) {
   options.hostname = options.hostname || hostname;
   options.proxy = options.proxy || null;
 
+  if(options.documentSizeCacheSize) {
+    Kadira.docSzCache = new DocSzCache(options.documentSizeCacheSize, 10);
+  }
+
   // remove trailing slash from endpoint url (if any)
   if(_.last(options.endpoint) === '/') {
     options.endpoint = options.endpoint.substr(0, options.endpoint.length - 1);


### PR DESCRIPTION
Number of items kept in the DocSzCache object can be configured by setting the option **documentSizeCacheSize**.