### PR TITLE
Fix meteorhacks:cluster multi-core

### DIFF
--- a/lib/kadira.js
+++ b/lib/kadira.js
@@ -29,7 +29,7 @@ Kadira.connect = function(appId, appSecret, options) {
   options.clientEngineSyncDelay = options.clientEngineSyncDelay || 10000;
   options.thresholds = options.thresholds || {};
   options.isHostNameSet = !!options.hostname;
-  options.hostname = options.hostname || hostname;  
+  options.hostname = options.hostname || hostname;
   options.proxy = options.proxy || null;
 
   if(options.documentSizeCacheSize) {
@@ -48,8 +48,8 @@ Kadira.connect = function(appId, appSecret, options) {
   
   if (Package['meteorhacks:cluster']) {
     if (process.env['CLUSTER_WORKER_ID']) {
-      // append worker id
-      hostname += `.${process.env['CLUSTER_WORKER_ID']}`;
+      // append id to indentify worker
+      options.hostname += `.${process.env['CLUSTER_WORKER_ID']}`;
     }
   }
 

--- a/lib/kadira.js
+++ b/lib/kadira.js
@@ -29,7 +29,7 @@ Kadira.connect = function(appId, appSecret, options) {
   options.clientEngineSyncDelay = options.clientEngineSyncDelay || 10000;
   options.thresholds = options.thresholds || {};
   options.isHostNameSet = !!options.hostname;
-  options.hostname = options.hostname || hostname;
+  options.hostname = options.hostname || hostname;  
   options.proxy = options.proxy || null;
 
   if(options.documentSizeCacheSize) {
@@ -44,6 +44,13 @@ Kadira.connect = function(appId, appSecret, options) {
   // error tracking is enabled by default
   if(options.enableErrorTracking === undefined) {
     options.enableErrorTracking = true;
+  }
+  
+  if (Package['meteorhacks:cluster']) {
+    if (process.env['CLUSTER_WORKER_ID']) {
+      // append worker id
+      hostname += `.${process.env['CLUSTER_WORKER_ID']}`;
+    }
   }
 
   Kadira.options = options;


### PR DESCRIPTION
Fixes https://github.com/meteorhacks/kadira/issues/248

If auto connect is active it is required that cluster is loaded first in .meteor/packages:
meteorhacks:cluster
meteorhacks:kadira

Cluster package:
https://github.com/meteorhacks/cluster/